### PR TITLE
Fix server port configuration

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -9,7 +9,9 @@ app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, '../views'));
 app.use(express.static('public'));
 
-const port = process.env.PORT || 3000;
+// Prefer the environment variable APP_PORT if provided for consistency with the
+// docker-compose and .env configuration. Fallback to PORT and then to 3000.
+const port = process.env.APP_PORT || process.env.PORT || 3000;
 
 app.listen(port, () => {
   console.log(`Server running on port ${port}`);


### PR DESCRIPTION
## Summary
- allow configuring the server port using `APP_PORT`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6880fc0dfb888327ad4fec6e8fcfc2fd