### PR TITLE
Add custom Jest runner and unit test

### DIFF
--- a/jest-runner.js
+++ b/jest-runner.js
@@ -1,0 +1,94 @@
+const fs = require('fs');
+const path = require('path');
+const Module = require('module');
+
+const tests = [];
+const mockModules = new Map();
+const originalRequire = Module.prototype.require;
+
+Module.prototype.require = function(name) {
+  if (mockModules.has(name)) {
+    return mockModules.get(name);
+  }
+  return originalRequire.apply(this, arguments);
+};
+
+// Simple test definitions
+global.describe = (_name, fn) => fn();
+
+global.it = (name, fn) => {
+  tests.push({ name, fn });
+};
+
+// Expect implementation
+function expect(received) {
+  return {
+    toBe(expected) {
+      if (received !== expected) {
+        throw new Error(`Expected ${expected} but received ${received}`);
+      }
+    },
+    toHaveBeenCalledWith(...args) {
+      if (!received || !received.mock) {
+        throw new Error('Expected a mocked function');
+      }
+      const calls = received.mock.calls;
+      const found = calls.some(call => JSON.stringify(call) === JSON.stringify(args));
+      if (!found) {
+        throw new Error(
+          `Expected to have been called with ${JSON.stringify(args)} but was called with ${JSON.stringify(calls)}`
+        );
+      }
+    },
+  };
+}
+
+global.expect = expect;
+
+global.jest = {
+  fn(impl) {
+    const fn = (...args) => {
+      fn.mock.calls.push(args);
+      if (fn.mock.impl) {
+        return fn.mock.impl(...args);
+      }
+    };
+    fn.mock = { calls: [], impl };
+    fn.mockResolvedValue = val => {
+      fn.mock.impl = () => Promise.resolve(val);
+    };
+    fn.mockImplementation = newImpl => {
+      fn.mock.impl = newImpl;
+    };
+    return fn;
+  },
+  mock(moduleName, factory) {
+    const stub = factory ? factory() : { get: jest.fn() };
+    mockModules.set(moduleName, stub);
+    return stub;
+  },
+};
+
+async function run() {
+  const dir = path.join(__dirname, 'services', '__tests__');
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.test.js'));
+  for (const file of files) {
+    require(path.join(dir, file));
+  }
+
+  let passed = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log(`\x1b[32m✓\x1b[0m ${t.name}`);
+      passed++;
+    } catch (err) {
+      console.error(`\x1b[31m✗ ${t.name}\x1b[0m`);
+      console.error(err);
+    }
+  }
+  console.log(`${passed}/${tests.length} tests passed`);
+  if (passed !== tests.length) process.exit(1);
+}
+
+run();

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node jest-runner.js"
   },
   "keywords": [],
   "author": "",
@@ -14,5 +14,8 @@
     "dotenv": "^16.4.7",
     "ejs": "^3.1.10",
     "express": "^4.21.1"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/services/__tests__/GetPackageVersion.test.js
+++ b/services/__tests__/GetPackageVersion.test.js
@@ -1,0 +1,18 @@
+jest.mock('axios');
+const axios = require('axios');
+const GetPackageVersion = require('../GetPackageVersion');
+
+describe('GetPackageVersion.latest', () => {
+  it('returns the latest version from npm', async () => {
+    const mockVersion = '1.2.3';
+    axios.get.mockResolvedValue({ data: { version: mockVersion } });
+
+    const service = GetPackageVersion.create();
+    const version = await service.latest('test-package');
+
+    expect(version).toBe(mockVersion);
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://registry.npmjs.org/test-package/latest'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- implement a small Jest-like runner so tests can run without external deps
- wire npm `test` script to use the runner
- adjust GetPackageVersion test for the new runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880fe393f3c8327b03c31b546617e86